### PR TITLE
sf: Initialize DispSync in SurfaceFlinger_hwc1

### DIFF
--- a/services/surfaceflinger/SurfaceFlinger_hwc1.cpp
+++ b/services/surfaceflinger/SurfaceFlinger_hwc1.cpp
@@ -178,6 +178,8 @@ SurfaceFlinger::SurfaceFlinger()
     maxFrameBufferAcquiredBuffers = getInt64< ISurfaceFlingerConfigs,
             &ISurfaceFlingerConfigs::maxFrameBufferAcquiredBuffers>(2);
 
+    mPrimaryDispSync.init(hasSyncFramework, dispSyncPresentTimeOffset);
+
     char value[PROPERTY_VALUE_MAX];
 
     property_get("ro.bq.gpu_to_cpu_unsupported", value, "0");


### PR DESCRIPTION
SurfaceFlinger_hwc1 was not initializing DispSync. The hw vsyncs
were not getting processed resulting in 1 frame per second.

Fixes b/65484547.

Test: Boot Hikey/Hikey960. Frame rate should be higher than
      1 frame per second.

Change-Id: I1a80be294488440abdf5f14ea3e1f3c9c773b21c